### PR TITLE
Fixed potential bug

### DIFF
--- a/src/main/java/com/thexfactor117/ce/ChemicalEnergistics.java
+++ b/src/main/java/com/thexfactor117/ce/ChemicalEnergistics.java
@@ -65,6 +65,7 @@ public class ChemicalEnergistics
 		
 		CEBlocks.registerBlocks();
 		CEItems.registerItems();
+		CERecipes.registerItemsToOreDict();
 		
 		GameRegistry.registerWorldGenerator(worldGen, 0);
 	}
@@ -73,7 +74,6 @@ public class ChemicalEnergistics
 	public void init(FMLInitializationEvent event)
 	{
 		CERecipes.registerRecipes();
-		CERecipes.registerItemsToOreDict();
 		proxy.registerTileEntities();
 		
 		NetworkRegistry.INSTANCE.registerGuiHandler(ChemicalEnergistics.instance, new GuiHandler());


### PR DESCRIPTION
The ore dictionary entries were being registered too late. Here's 2 reasons why:
1. You registered them after the recipes. This meaning ore dictionary-influenced recipes wouldn't work.
2. You registered them in the second phase. Other mods using ore dict. recipes might not see your ore dictionary entries.